### PR TITLE
Updates to use tasks.register() instead of tasks.create()

### DIFF
--- a/contents/index.adoc
+++ b/contents/index.adoc
@@ -12,6 +12,13 @@ The guide assumes you have:
 
 If you happen to be a beginner to Gradle please start by working through the link:https://gradle.org/guides#getting-started[Getting Started Guides on Gradle development] first while referencing the {user-manual}userguide.html[Gradle User Manual] to go deeper.
 
+== What you'll need
+
+* About +++<span class="time-to-complete-text"></span>+++
+* A text editor or IDE
+* A Java Development Kit (JDK), version 1.8 or better
+* A https://gradle.org/install[Gradle distribution], version {gradle-version} or better
+
 == Practices
 
 [[plugin-development-plugin]]

--- a/samples/code/react-to-task/build.gradle
+++ b/samples/code/react-to-task/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: InhouseConventionWarPlugin
 
-task war(type: War)
+tasks.register("war", War)
 
-task assertWarWebXml {
+tasks.register("assertWarWebXml") {
     doLast {
         assert war.webXml == file('src/someWeb.xml')
     }

--- a/samples/code/react-to-task/buildSrc/src/main/java/InhouseConventionWarPlugin.java
+++ b/samples/code/react-to-task/buildSrc/src/main/java/InhouseConventionWarPlugin.java
@@ -5,7 +5,7 @@ import org.gradle.api.tasks.bundling.War;
 
 public class InhouseConventionWarPlugin implements Plugin<Project> {
     public void apply(Project project) {
-        project.getTasks().withType(War.class, new Action<War>() {
+        project.getTasks().withType(War.class).configureEach(new Action<War>() {
             public void execute(War war) {
                 war.setWebXml(project.file("src/someWeb.xml"));
             }

--- a/samples/groovy-dsl/code/capture-user-input/buildSrc/src/main/java/BinaryRepositoryVersionPlugin.java
+++ b/samples/groovy-dsl/code/capture-user-input/buildSrc/src/main/java/BinaryRepositoryVersionPlugin.java
@@ -6,7 +6,7 @@ public class BinaryRepositoryVersionPlugin implements Plugin<Project> {
     public void apply(Project project) {
         BinaryRepositoryExtension extension = project.getExtensions().create("binaryRepo", BinaryRepositoryExtension.class, project);
 
-        project.getTasks().create("latestArtifactVersion", LatestArtifactVersion.class, new Action<LatestArtifactVersion>() {
+        project.getTasks().register("latestArtifactVersion", LatestArtifactVersion.class, new Action<LatestArtifactVersion>() {
             public void execute(LatestArtifactVersion latestArtifactVersion) {
                 latestArtifactVersion.getServerUrl().set(extension.getServerUrl());
             }

--- a/samples/groovy-dsl/code/custom-task/build.gradle
+++ b/samples/groovy-dsl/code/custom-task/build.gradle
@@ -1,11 +1,11 @@
 import com.company.gradle.binaryrepo.LatestArtifactVersion
 
-task latestVersionMavenCentral(type: LatestArtifactVersion) {
+tasks.register("latestVersionMavenCentral", LatestArtifactVersion) {
     coordinates = 'commons-lang:commons-lang:1.5'
     serverUrl = 'http://repo1.maven.org/maven2/'
 }
 
-task latestVersionInhouseRepo(type: LatestArtifactVersion) {
+tasks.register("latestVersionInhouseRepo", LatestArtifactVersion) {
     coordinates = 'commons-lang:commons-lang:2.6'
     serverUrl = 'http://my.company.com/maven2'
 }

--- a/samples/groovy-dsl/code/default-dependency/buildSrc/src/main/java/DataProcessingPlugin.java
+++ b/samples/groovy-dsl/code/default-dependency/buildSrc/src/main/java/DataProcessingPlugin.java
@@ -16,7 +16,7 @@ public class DataProcessingPlugin implements Plugin<Project> {
             }
         });
 
-        project.getTasks().withType(DataProcessing.class, new Action<DataProcessing>() {
+        project.getTasks().withType(DataProcessing.class).configureEach(new Action<DataProcessing>() {
             public void execute(DataProcessing dataProcessing) {
                 dataProcessing.setDataFiles(config);
             }

--- a/samples/groovy-dsl/code/incremental-task/build.gradle
+++ b/samples/groovy-dsl/code/incremental-task/build.gradle
@@ -1,4 +1,4 @@
-task generate(type: Generate) {
+tasks.register("generate", Generate) {
     fileCount = 2
     content = 'Hello World!'
     generatedFileDir = file("$buildDir/generated-output")

--- a/samples/groovy-dsl/code/named-domain-object-container/buildSrc/src/main/java/Deploy.java
+++ b/samples/groovy-dsl/code/named-domain-object-container/buildSrc/src/main/java/Deploy.java
@@ -1,21 +1,26 @@
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.provider.Property;
+import org.gradle.api.model.ObjectFactory;
+
+import javax.inject.Inject;
 
 public class Deploy extends DefaultTask {
-    private String url;
+    private Property<String> url;
 
-    public void setUrl(String url) {
-        this.url = url;
+    @Inject
+    public Deploy(ObjectFactory objects) {
+        this.url = objects.property(String.class);
     }
-    
+
     @Input
-    public String getUrl() {
+    public Property<String> getUrl() {
         return url;
     }
     
     @TaskAction
     public void deploy() {
-        System.out.println("Deploying to URL " + url);
+        System.out.println("Deploying to URL " + url.get());
     }
 }

--- a/samples/groovy-dsl/code/named-domain-object-container/buildSrc/src/main/java/ServerEnvironment.java
+++ b/samples/groovy-dsl/code/named-domain-object-container/buildSrc/src/main/java/ServerEnvironment.java
@@ -1,20 +1,26 @@
+import org.gradle.api.provider.Property;
+import org.gradle.api.model.ObjectFactory;
+
+import javax.inject.Inject;
+
 public class ServerEnvironment {
     private final String name;
-    private String url;
+    private Property<String> url;
 
-    public ServerEnvironment(String name) {
+    public ServerEnvironment(String name, ObjectFactory objectFactory) {
         this.name = name;
+        this.url = objectFactory.property(String.class);
     }
-    
+
+    public void setUrl(String url) {
+        this.url.set(url);
+    }
+
     public String getName() {
         return name;
     }
     
-    public void setUrl(String url) {
-        this.url = url;
-    }
-    
-    public String getUrl() {
+    public Property<String> getUrl() {
         return url;
     }
 }

--- a/samples/groovy-dsl/code/named-domain-object-container/buildSrc/src/main/java/ServerEnvironmentPlugin.java
+++ b/samples/groovy-dsl/code/named-domain-object-container/buildSrc/src/main/java/ServerEnvironmentPlugin.java
@@ -2,8 +2,12 @@ import org.gradle.api.*;
 
 public class ServerEnvironmentPlugin implements Plugin<Project> {
     @Override
-    public void apply(Project project) {
-        NamedDomainObjectContainer<ServerEnvironment> serverEnvironmentContainer = project.container(ServerEnvironment.class);
+    public void apply(final Project project) {
+        NamedDomainObjectContainer<ServerEnvironment> serverEnvironmentContainer = project.container(ServerEnvironment.class, new NamedDomainObjectFactory<ServerEnvironment>() {
+            public ServerEnvironment create(String name) {
+                return new ServerEnvironment(name, project.getObjects());
+            }
+        });
         project.getExtensions().add("environments", serverEnvironmentContainer);
 
         serverEnvironmentContainer.all(new Action<ServerEnvironment>() {
@@ -13,7 +17,7 @@ public class ServerEnvironmentPlugin implements Plugin<Project> {
                 String taskName = "deployTo" + capitalizedServerEnv;
                 project.getTasks().register(taskName, Deploy.class, new Action<Deploy>() {
                     public void execute(Deploy task) {
-                        task.setUrl(serverEnvironment.getUrl());
+                        task.getUrl().set(serverEnvironment.getUrl());
                     }
                 });
             }

--- a/samples/groovy-dsl/code/named-domain-object-container/buildSrc/src/main/java/ServerEnvironmentPlugin.java
+++ b/samples/groovy-dsl/code/named-domain-object-container/buildSrc/src/main/java/ServerEnvironmentPlugin.java
@@ -11,11 +11,9 @@ public class ServerEnvironmentPlugin implements Plugin<Project> {
                 String env = serverEnvironment.getName();
                 String capitalizedServerEnv = env.substring(0, 1).toUpperCase() + env.substring(1);
                 String taskName = "deployTo" + capitalizedServerEnv;
-                Deploy deployTask = project.getTasks().create(taskName, Deploy.class);
-                
-                project.afterEvaluate(new Action<Project>() {
-                    public void execute(Project project) {
-                        deployTask.setUrl(serverEnvironment.getUrl());
+                project.getTasks().register(taskName, Deploy.class, new Action<Deploy>() {
+                    public void execute(Deploy task) {
+                        task.setUrl(serverEnvironment.getUrl());
                     }
                 });
             }

--- a/samples/kotlin-dsl/code/capture-user-input/buildSrc/src/main/java/BinaryRepositoryVersionPlugin.java
+++ b/samples/kotlin-dsl/code/capture-user-input/buildSrc/src/main/java/BinaryRepositoryVersionPlugin.java
@@ -6,7 +6,7 @@ public class BinaryRepositoryVersionPlugin implements Plugin<Project> {
     public void apply(Project project) {
         BinaryRepositoryExtension extension = project.getExtensions().create("binaryRepo", BinaryRepositoryExtension.class, project);
 
-        project.getTasks().create("latestArtifactVersion", LatestArtifactVersion.class, new Action<LatestArtifactVersion>() {
+        project.getTasks().register("latestArtifactVersion", LatestArtifactVersion.class, new Action<LatestArtifactVersion>() {
             public void execute(LatestArtifactVersion latestArtifactVersion) {
                 latestArtifactVersion.getServerUrl().set(extension.getServerUrl());
             }

--- a/samples/kotlin-dsl/code/custom-task/build.gradle.kts
+++ b/samples/kotlin-dsl/code/custom-task/build.gradle.kts
@@ -1,11 +1,11 @@
 import com.company.gradle.binaryrepo.LatestArtifactVersion
 
-tasks.create<LatestArtifactVersion>("latestVersionMavenCentral") {
+tasks.register<LatestArtifactVersion>("latestVersionMavenCentral") {
     coordinates = "commons-lang:commons-lang:1.5"
     serverUrl = "http://repo1.maven.org/maven2/"
 }
 
-tasks.create<LatestArtifactVersion>("latestVersionInhouseRepo") {
+tasks.register<LatestArtifactVersion>("latestVersionInhouseRepo") {
     coordinates = "commons-lang:commons-lang:2.6"
     serverUrl = "http://my.company.com/maven2"
 }

--- a/samples/kotlin-dsl/code/default-dependency/buildSrc/src/main/java/DataProcessingPlugin.java
+++ b/samples/kotlin-dsl/code/default-dependency/buildSrc/src/main/java/DataProcessingPlugin.java
@@ -16,7 +16,7 @@ public class DataProcessingPlugin implements Plugin<Project> {
             }
         });
 
-        project.getTasks().withType(DataProcessing.class, new Action<DataProcessing>() {
+        project.getTasks().withType(DataProcessing.class).configureEach(new Action<DataProcessing>() {
             public void execute(DataProcessing dataProcessing) {
                 dataProcessing.setDataFiles(config);
             }

--- a/samples/kotlin-dsl/code/incremental-task/build.gradle.kts
+++ b/samples/kotlin-dsl/code/incremental-task/build.gradle.kts
@@ -1,6 +1,6 @@
 import Generate
 
-tasks.create<Generate>("generate") {
+tasks.register<Generate>("generate") {
     fileCount = 2
     content = "Hello World!"
     generatedFileDir = file("$buildDir/generated-output")

--- a/samples/kotlin-dsl/code/named-domain-object-container/build.gradle.kts
+++ b/samples/kotlin-dsl/code/named-domain-object-container/build.gradle.kts
@@ -5,14 +5,14 @@ apply<ServerEnvironmentPlugin>()
 
 configure<NamedDomainObjectContainer<ServerEnvironment>> {
     create("dev") {
-        url = "http://localhost:8080"
+        url.set("http://localhost:8080")
     }
 
     create("staging") {
-        url = "http://staging.enterprise.com"
+        url.set("http://staging.enterprise.com")
     }
 
     create("production") {
-        url = "http://prod.enterprise.com"
+        url.set("http://prod.enterprise.com")
     }
 }

--- a/samples/kotlin-dsl/code/named-domain-object-container/buildSrc/src/main/java/Deploy.java
+++ b/samples/kotlin-dsl/code/named-domain-object-container/buildSrc/src/main/java/Deploy.java
@@ -1,21 +1,26 @@
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.provider.Property;
+import org.gradle.api.model.ObjectFactory;
+
+import javax.inject.Inject;
 
 public class Deploy extends DefaultTask {
-    private String url;
+    private Property<String> url;
 
-    public void setUrl(String url) {
-        this.url = url;
+    @Inject
+    public Deploy(ObjectFactory objects) {
+        this.url = objects.property(String.class);
     }
-    
+
     @Input
-    public String getUrl() {
+    public Property<String> getUrl() {
         return url;
     }
     
     @TaskAction
     public void deploy() {
-        System.out.println("Deploying to URL " + url);
+        System.out.println("Deploying to URL " + url.get());
     }
 }

--- a/samples/kotlin-dsl/code/named-domain-object-container/buildSrc/src/main/java/ServerEnvironment.java
+++ b/samples/kotlin-dsl/code/named-domain-object-container/buildSrc/src/main/java/ServerEnvironment.java
@@ -7,6 +7,7 @@ public class ServerEnvironment {
     private final String name;
     private Property<String> url;
 
+    @Inject
     public ServerEnvironment(String name, ObjectFactory objectFactory) {
         this.name = name;
         this.url = objectFactory.property(String.class);

--- a/samples/kotlin-dsl/code/named-domain-object-container/buildSrc/src/main/java/ServerEnvironment.java
+++ b/samples/kotlin-dsl/code/named-domain-object-container/buildSrc/src/main/java/ServerEnvironment.java
@@ -1,20 +1,26 @@
+import org.gradle.api.provider.Property;
+import org.gradle.api.model.ObjectFactory;
+
+import javax.inject.Inject;
+
 public class ServerEnvironment {
     private final String name;
-    private String url;
+    private Property<String> url;
 
-    public ServerEnvironment(String name) {
+    public ServerEnvironment(String name, ObjectFactory objectFactory) {
         this.name = name;
+        this.url = objectFactory.property(String.class);
     }
-    
+
+    public void setUrl(String url) {
+        this.url.set(url);
+    }
+
     public String getName() {
         return name;
     }
     
-    public void setUrl(String url) {
-        this.url = url;
-    }
-    
-    public String getUrl() {
+    public Property<String> getUrl() {
         return url;
     }
 }

--- a/samples/kotlin-dsl/code/named-domain-object-container/buildSrc/src/main/java/ServerEnvironmentPlugin.java
+++ b/samples/kotlin-dsl/code/named-domain-object-container/buildSrc/src/main/java/ServerEnvironmentPlugin.java
@@ -2,8 +2,12 @@ import org.gradle.api.*;
 
 public class ServerEnvironmentPlugin implements Plugin<Project> {
     @Override
-    public void apply(Project project) {
-        NamedDomainObjectContainer<ServerEnvironment> serverEnvironmentContainer = project.container(ServerEnvironment.class);
+    public void apply(final Project project) {
+        NamedDomainObjectContainer<ServerEnvironment> serverEnvironmentContainer = project.container(ServerEnvironment.class, new NamedDomainObjectFactory<ServerEnvironment>() {
+            public ServerEnvironment create(String name) {
+                return new ServerEnvironment(name, project.getObjects());
+            }
+        });
         project.getExtensions().add("environments", serverEnvironmentContainer);
 
         serverEnvironmentContainer.all(new Action<ServerEnvironment>() {
@@ -13,7 +17,7 @@ public class ServerEnvironmentPlugin implements Plugin<Project> {
                 String taskName = "deployTo" + capitalizedServerEnv;
                 project.getTasks().register(taskName, Deploy.class, new Action<Deploy>() {
                     public void execute(Deploy task) {
-                        task.setUrl(serverEnvironment.getUrl());
+                        task.getUrl().set(serverEnvironment.getUrl());
                     }
                 });
             }

--- a/samples/kotlin-dsl/code/named-domain-object-container/buildSrc/src/main/java/ServerEnvironmentPlugin.java
+++ b/samples/kotlin-dsl/code/named-domain-object-container/buildSrc/src/main/java/ServerEnvironmentPlugin.java
@@ -5,7 +5,7 @@ public class ServerEnvironmentPlugin implements Plugin<Project> {
     public void apply(final Project project) {
         NamedDomainObjectContainer<ServerEnvironment> serverEnvironmentContainer = project.container(ServerEnvironment.class, new NamedDomainObjectFactory<ServerEnvironment>() {
             public ServerEnvironment create(String name) {
-                return new ServerEnvironment(name, project.getObjects());
+                return project.getObjects().newInstance(ServerEnvironment.class, name, project.getObjects());
             }
         });
         project.getExtensions().add("environments", serverEnvironmentContainer);

--- a/samples/kotlin-dsl/code/named-domain-object-container/buildSrc/src/main/java/ServerEnvironmentPlugin.java
+++ b/samples/kotlin-dsl/code/named-domain-object-container/buildSrc/src/main/java/ServerEnvironmentPlugin.java
@@ -11,11 +11,9 @@ public class ServerEnvironmentPlugin implements Plugin<Project> {
                 String env = serverEnvironment.getName();
                 String capitalizedServerEnv = env.substring(0, 1).toUpperCase() + env.substring(1);
                 String taskName = "deployTo" + capitalizedServerEnv;
-                Deploy deployTask = project.getTasks().create(taskName, Deploy.class);
-                
-                project.afterEvaluate(new Action<Project>() {
-                    public void execute(Project project) {
-                        deployTask.setUrl(serverEnvironment.getUrl());
+                project.getTasks().register(taskName, Deploy.class, new Action<Deploy>() {
+                    public void execute(Deploy task) {
+                        task.setUrl(serverEnvironment.getUrl());
                     }
                 });
             }


### PR DESCRIPTION
Updated to reflect the recommended way to register new tasks.